### PR TITLE
Make dataset optional for GeneEmbedding

### DIFF
--- a/genevector/embedding.py
+++ b/genevector/embedding.py
@@ -48,7 +48,7 @@ class GeneEmbedding(object):
     :type vector: str
     """
 
-    def __init__(self, embedding_file, dataset, vector="average"):
+    def __init__(self, embedding_file, dataset = None, vector="average"):
         """Constructor method
         """
         if vector not in ("1","2","average"):
@@ -67,6 +67,8 @@ class GeneEmbedding(object):
             secondary_weights = embedding_file.replace(".vec","2.vec")
             self.embeddings = self.read_embedding(secondary_weights)
         self.vector = []
+        if dataset is not None:
+            self.context = dataset.data
         self.context = dataset.data
         self.embedding_file = embedding_file
         self.vector = []


### PR DESCRIPTION
`GeneEmbedding` is a very useful class for running inference with pretrained embeddings but requires a currently unused `GeneVectorDataset` argument. For large-ish datasets this is fairly expensive (e.g. a ~500 Mb .h5ad is ~2GB when cast to `GeneVectorDataset` with `load_expression=False`, ~50GB with the default `load_expression=True`). This small PR makes the dataset argument optional in `GeneEmbedding`.